### PR TITLE
[FIX] Read the rule set once per request and accept regex patterns with slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ matches `archive/posts/hello`. A pattern that does not compile is skipped, so a 
 rule can never take the redirector down — but it will silently never fire, so test it after
 saving.
 
-Regex rules are evaluated before exact ones, in id order, and the first match wins.
+Regex rules are evaluated before exact ones, in id order, and the first match wins — that
+also applies to two exact rules sharing the same **From URL**: the lower id is used.
+
+Patterns are never rewritten before compiling: the expression is wrapped in one of
+`# ~ ! @ ; , % = | +`, whichever it does not already contain, so constructs like
+`(?#comment)` keep their meaning. A pattern containing all ten is skipped.
 
 ### Caching
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ You can add this middleware to your `app/Http/Kernel.php` file:
         //...
 ```
 
+### Writing rules
+
+**From URL** is matched against the request path, without the leading slash: write `old-page`
+or `blog/old-post`, not `/old-page`. **To URL** is passed to Laravel's redirector, so both a
+path (`/new-page`) and an absolute URL (`https://example.com/new-page`) work.
+
+Tick **Is Regex** to match a family of paths. Patterns are stored as bare expressions — no
+delimiters — and slashes need no escaping:
+
+| From URL | To URL | Result |
+|---|---|---|
+| `posts/(.*)` | `/articles/$1` | `posts/hello` → `/articles/hello` |
+| `^shop/(\d+)$` | `/products/$1` | `shop/42` → `/products/42` |
+
+Capture groups are available in **To URL** as `$1`, `$2`, and so on. Anchor the pattern with
+`^` and `$` unless you deliberately want to match anywhere in the path: `posts/(.*)` also
+matches `archive/posts/hello`. A pattern that does not compile is skipped, so a malformed
+rule can never take the redirector down — but it will silently never fire, so test it after
+saving.
+
+Regex rules are evaluated before exact ones, in id order, and the first match wins.
+
+### Caching
+
+Every enabled rule is kept in a **single** cache entry, and the whole set is read once per
+request. The cache is flushed automatically whenever a rule is created, updated, deleted or
+restored, so changes made in Nova take effect immediately.
+
+Set `cache.ttl` to `null` or `0` to read the rules from the database on every request. This
+is only worth doing while debugging: the middleware runs on every request your application
+serves.
+
 ### Policies
 
 You can add a policy to the NovaRedirectorSeo resource, to restrict the access to the resource.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,2 @@
-- Support for regex and wildcards
-- Tests (I know, I know)
 - Translation setup and files
-- PHPstan fixes
+- Support status codes other than 301/302 (410 Gone would need a non-redirect response)

--- a/config/nova-redirector-seo.php
+++ b/config/nova-redirector-seo.php
@@ -3,6 +3,12 @@
 // config for The3LabsTeam/NovaRedirectorSeo
 return [
     'cache' => [
+        /*
+         * How long the rule set is kept in the cache store. Every enabled rule lives in a
+         * single entry, refreshed automatically whenever a rule changes, so this only caps
+         * how long a change made outside the model (a raw query, a database import) takes
+         * to appear. Set it to null or 0 to read from the database on every request.
+         */
         'ttl' => 60 * 60 * 24 * 7, // 7 days
     ],
 ];

--- a/src/App/Helpers/NovaRedirectorSeoHelper.php
+++ b/src/App/Helpers/NovaRedirectorSeoHelper.php
@@ -7,6 +7,14 @@ use The3LabsTeam\NovaRedirectorSeo\App\Models\NovaRedirectorSeo;
 class NovaRedirectorSeoHelper
 {
     /**
+     * Delimiter candidates for stored patterns, in order of preference. Slashes are
+     * absent on purpose: they are the one character every URL pattern contains.
+     *
+     * @var array<int, string>
+     */
+    private const DELIMITERS = ['#', '~', '!', '@', ';', ',', '%', '=', '|', '+'];
+
+    /**
      * The first function to be called when the redirect is triggered.
      * It will check if the given path matches to any regex or exact rule.
      * If it matches, it will return the redirect object.
@@ -71,6 +79,10 @@ class NovaRedirectorSeoHelper
                 continue;
             }
 
+            if (array_key_exists($rule->from_url, $rules['exact'])) {
+                continue;
+            }
+
             $rules['exact'][$rule->from_url] = [
                 'to_url' => $rule->to_url,
                 'status_code' => (int) $rule->status_code,
@@ -127,21 +139,28 @@ class NovaRedirectorSeoHelper
     }
 
     /**
-     * Wrap a stored pattern in a delimiter it is allowed to contain.
+     * Wrap a stored pattern in a delimiter the pattern does not contain.
      *
      * Rules are written as bare expressions such as `posts/(.*)`, so slashes are
-     * expected and must not end the expression: `#` is used as the delimiter and
-     * escaped where the author wrote it literally. Returns null when the pattern
-     * does not compile, so one broken rule cannot take the redirector down.
+     * expected and must not end the expression. The pattern itself is never
+     * rewritten: escaping an occurrence would change the constructs that give
+     * that character meaning — `(?#comment)`, or `#` starting a comment under
+     * the `x` modifier — so a delimiter absent from the pattern is picked
+     * instead. Returns null when the pattern does not compile, so one broken
+     * rule cannot take the redirector down.
      */
     private static function compilePattern(string $pattern): ?string
     {
-        $delimited = '#'.preg_replace('/(?<!\\\\)#/', '\\#', $pattern).'#';
+        foreach (self::DELIMITERS as $delimiter) {
+            if (str_contains($pattern, $delimiter)) {
+                continue;
+            }
 
-        if (@preg_match($delimited, '') === false) {
-            return null;
+            $delimited = $delimiter.$pattern.$delimiter;
+
+            return @preg_match($delimited, '') === false ? null : $delimited;
         }
 
-        return $delimited;
+        return null;
     }
 }

--- a/src/App/Helpers/NovaRedirectorSeoHelper.php
+++ b/src/App/Helpers/NovaRedirectorSeoHelper.php
@@ -13,11 +13,92 @@ class NovaRedirectorSeoHelper
      */
     public static function handle(string $path): ?object
     {
-        $redirect = self::challengeRegex($path) ?? self::challengeExact($path) ?? null;
-        if ($redirect) {
+        $rules = self::rules();
+
+        return self::challengeRegex($rules['regex'], $path)
+            ?? self::challengeExact($rules['exact'], $path);
+    }
+
+    /**
+     * Every enabled rule, kept in a single cache entry.
+     *
+     * The whole set is cached at once instead of one entry per visited path: the
+     * rules are few and shared by every request, while the paths are unbounded —
+     * a crawler alone visits enough distinct URLs to fill the cache store with
+     * entries that are never read twice.
+     *
+     * @return array{exact: array<string, array{to_url: string, status_code: int}>, regex: array<int, array{from_url: string, to_url: string, status_code: int}>}
+     */
+    private static function rules(): array
+    {
+        $ttl = config('nova-redirector-seo.cache.ttl');
+
+        if ($ttl === null || (int) $ttl < 1) {
+            return self::loadRules();
+        }
+
+        return cache()->remember(
+            NovaRedirectorSeo::cacheKey(),
+            (int) $ttl,
+            static fn (): array => self::loadRules(),
+        );
+    }
+
+    /**
+     * @return array{exact: array<string, array{to_url: string, status_code: int}>, regex: array<int, array{from_url: string, to_url: string, status_code: int}>}
+     */
+    private static function loadRules(): array
+    {
+        $rules = ['exact' => [], 'regex' => []];
+
+        $enabled = NovaRedirectorSeo::query()
+            ->where('enabled', true)
+            ->orderBy('id')
+            ->get(['from_url', 'to_url', 'status_code', 'is_regex']);
+
+        foreach ($enabled as $rule) {
+            if ($rule->from_url === '' || $rule->to_url === '') {
+                continue;
+            }
+
+            if ($rule->is_regex) {
+                $rules['regex'][] = [
+                    'from_url' => $rule->from_url,
+                    'to_url' => $rule->to_url,
+                    'status_code' => (int) $rule->status_code,
+                ];
+
+                continue;
+            }
+
+            $rules['exact'][$rule->from_url] = [
+                'to_url' => $rule->to_url,
+                'status_code' => (int) $rule->status_code,
+            ];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Determine if the given path matches to any regex rule.
+     * If it matches, return the redirect object.
+     * If it doesn't match, return null.
+     *
+     * @param  array<int, array{from_url: string, to_url: string, status_code: int}>  $rules
+     */
+    private static function challengeRegex(array $rules, string $path): ?object
+    {
+        foreach ($rules as $rule) {
+            $pattern = self::compilePattern($rule['from_url']);
+
+            if ($pattern === null || preg_match($pattern, $path) !== 1) {
+                continue;
+            }
+
             return (object) [
-                'to_url' => $redirect->to_url,
-                'status_code' => $redirect->status_code,
+                'to_url' => preg_replace($pattern, $rule['to_url'], $path),
+                'status_code' => $rule['status_code'],
             ];
         }
 
@@ -25,68 +106,42 @@ class NovaRedirectorSeoHelper
     }
 
     /**
-     * Determine if the given path matches to any regex saved in the database.
+     * Determine if the given path matches to any exact rule.
      * If it matches, return the redirect object.
      * If it doesn't match, return null.
      *
-     * @return object|null
+     * @param  array<string, array{to_url: string, status_code: int}>  $rules
      */
-    private static function challengeRegex(string $path)
+    private static function challengeExact(array $rules, string $path): ?object
     {
-        $regexRules = NovaRedirectorSeo::where('enabled', true)
-            ->where('is_regex', true)
-            ->get();
+        $rule = $rules[$path] ?? null;
 
-        foreach ($regexRules as $regex) {
-            if (self::testRegex($regex->from_url, $path)) {
-                $toUrl = preg_replace("/$regex->from_url/", $regex->to_url, $path);
-
-                return (object) [
-                    'to_url' => $toUrl,
-                    'status_code' => $regex->status_code,
-                ];
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Determine if the given path matches to any exact saved in the database.
-     * If it matches, return the redirect object.
-     * If it doesn't match, return null.
-     *
-     * @return object|null
-     */
-    private static function challengeExact(string $path)
-    {
-        $query = NovaRedirectorSeo::where('from_url', $path)
-            ->where('enabled', true)
-            ->where('is_regex', false)
-            ->first();
-        $fromUrl = $query->from_url ?? null;
-        $toUrl = $query->to_url ?? null;
-        $statusCode = $query->status_code ?? 301;
-
-        if (! $fromUrl || ! $toUrl) {
+        if ($rule === null) {
             return null;
         }
 
         return (object) [
-            'to_url' => $toUrl,
-            'status_code' => $statusCode,
+            'to_url' => $rule['to_url'],
+            'status_code' => $rule['status_code'] ?: 301,
         ];
     }
 
     /**
-     * Test if the regex provided by the user is valid.
+     * Wrap a stored pattern in a delimiter it is allowed to contain.
+     *
+     * Rules are written as bare expressions such as `posts/(.*)`, so slashes are
+     * expected and must not end the expression: `#` is used as the delimiter and
+     * escaped where the author wrote it literally. Returns null when the pattern
+     * does not compile, so one broken rule cannot take the redirector down.
      */
-    private static function testRegex(string $regex, string $path): bool
+    private static function compilePattern(string $pattern): ?string
     {
-        if (@preg_match("/$regex/", '') === false) {
-            return false;
+        $delimited = '#'.preg_replace('/(?<!\\\\)#/', '\\#', $pattern).'#';
+
+        if (@preg_match($delimited, '') === false) {
+            return null;
         }
 
-        return preg_match("/$regex/", $path) === 1;
+        return $delimited;
     }
 }

--- a/src/App/Http/Middleware/NovaRedirectorSeoMiddleware.php
+++ b/src/App/Http/Middleware/NovaRedirectorSeoMiddleware.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Redirect;
 use The3LabsTeam\NovaRedirectorSeo\App\Helpers\NovaRedirectorSeoHelper;
-use The3LabsTeam\NovaRedirectorSeo\App\Models\NovaRedirectorSeo;
 
 class NovaRedirectorSeoMiddleware
 {
@@ -20,27 +19,12 @@ class NovaRedirectorSeoMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $redirect = $this->resolveRedirect($request->path());
+        $redirect = NovaRedirectorSeoHelper::handle($request->path());
 
         if ($redirect) {
             return Redirect::to($redirect->to_url, $redirect->status_code);
         }
 
         return $next($request);
-    }
-
-    private function resolveRedirect(string $path): ?object
-    {
-        $ttl = config('nova-redirector-seo.cache.ttl');
-
-        if ($ttl === null || (int) $ttl < 1) {
-            return NovaRedirectorSeoHelper::handle($path);
-        }
-
-        return cache()->remember(
-            NovaRedirectorSeo::cacheKey($path),
-            (int) $ttl,
-            static fn (): ?object => NovaRedirectorSeoHelper::handle($path),
-        );
     }
 }

--- a/src/App/Models/NovaRedirectorSeo.php
+++ b/src/App/Models/NovaRedirectorSeo.php
@@ -33,13 +33,16 @@ class NovaRedirectorSeo extends Model
         ];
     }
 
-    public static function cacheKey(string $fromUrl): string
+    /**
+     * The single entry holding every enabled rule.
+     */
+    public static function cacheKey(): string
     {
-        return "nova-redirector-seo.{$fromUrl}";
+        return 'nova-redirector-seo.rules';
     }
 
     public function clearCache(): void
     {
-        cache()->forget(self::cacheKey($this->from_url));
+        cache()->forget(self::cacheKey());
     }
 }

--- a/src/App/Observers/NovaRedirectorSeoObserver.php
+++ b/src/App/Observers/NovaRedirectorSeoObserver.php
@@ -8,62 +8,41 @@ class NovaRedirectorSeoObserver
 {
     /**
      * Handle the NovaRedirectorSeo "created" event.
-     *
-     * @return void
      */
-    public function created(NovaRedirectorSeo $novaRedirectorSeo)
+    public function created(NovaRedirectorSeo $novaRedirectorSeo): void
     {
-        $this->clearCache($novaRedirectorSeo);
+        $novaRedirectorSeo->clearCache();
     }
 
     /**
      * Handle the NovaRedirectorSeo "updated" event.
-     *
-     * @return void
      */
-    public function updated(NovaRedirectorSeo $novaRedirectorSeo)
+    public function updated(NovaRedirectorSeo $novaRedirectorSeo): void
     {
-        $this->clearCache($novaRedirectorSeo);
+        $novaRedirectorSeo->clearCache();
     }
 
     /**
      * Handle the NovaRedirectorSeo "deleted" event.
-     *
-     * @return void
      */
-    public function deleted(NovaRedirectorSeo $novaRedirectorSeo)
+    public function deleted(NovaRedirectorSeo $novaRedirectorSeo): void
     {
-        $this->clearCache($novaRedirectorSeo);
+        $novaRedirectorSeo->clearCache();
     }
 
     /**
      * Handle the NovaRedirectorSeo "restored" event.
-     *
-     * @return void
      */
-    public function restored(NovaRedirectorSeo $novaRedirectorSeo)
+    public function restored(NovaRedirectorSeo $novaRedirectorSeo): void
     {
-        $this->clearCache($novaRedirectorSeo);
+        $novaRedirectorSeo->clearCache();
     }
 
     /**
      * Handle the NovaRedirectorSeo "force deleted" event.
-     *
-     * @return void
      */
-    public function forceDeleted(NovaRedirectorSeo $novaRedirectorSeo)
+    public function forceDeleted(NovaRedirectorSeo $novaRedirectorSeo): void
     {
-        $this->clearCache($novaRedirectorSeo);
-    }
-
-    private function clearCache(NovaRedirectorSeo $novaRedirectorSeo): void
-    {
-        $originalPath = $novaRedirectorSeo->getOriginal('from_url');
-
-        if (is_string($originalPath) && $originalPath !== '') {
-            cache()->forget(NovaRedirectorSeo::cacheKey($originalPath));
-        }
-
         $novaRedirectorSeo->clearCache();
     }
 }

--- a/tests/Feature/NovaRedirectorSeoMiddlewareTest.php
+++ b/tests/Feature/NovaRedirectorSeoMiddlewareTest.php
@@ -42,6 +42,38 @@ class NovaRedirectorSeoMiddlewareTest extends TestCase
         $this->get('/posts/hello-world')->assertRedirect('/articles/hello-world');
     }
 
+    public function test_it_keeps_the_first_rule_when_two_exact_rules_share_a_path(): void
+    {
+        $this->createRule('old-page', '/first-destination', statusCode: 301);
+        $this->createRule('old-page', '/second-destination', statusCode: 302);
+
+        $response = $this->get('/old-page');
+
+        $response->assertRedirect('/first-destination');
+        $this->assertSame(301, $response->getStatusCode());
+    }
+
+    public function test_it_expands_regex_matches_containing_an_inline_comment(): void
+    {
+        $this->createRule('^posts/(.*)(?#legacy blog)$', '/articles/$1', isRegex: true);
+
+        $this->get('/posts/hello-world')->assertRedirect('/articles/hello-world');
+    }
+
+    public function test_it_expands_regex_matches_containing_several_delimiter_candidates(): void
+    {
+        $this->createRule('^p(?#c)/([~]+)$', '/articles/$1', isRegex: true);
+
+        $this->get('/p/~~')->assertRedirect('/articles/~~');
+    }
+
+    public function test_it_ignores_a_pattern_that_contains_every_delimiter_candidate(): void
+    {
+        $this->createRule('^p/([#~!@;,%=|+]+)$', '/articles/$1', isRegex: true);
+
+        $this->get('/p/abc')->assertSee('fallback-response');
+    }
+
     public function test_it_ignores_disabled_rules(): void
     {
         $this->createRule('old-page', '/new-page', enabled: false);

--- a/tests/Feature/NovaRedirectorSeoMiddlewareTest.php
+++ b/tests/Feature/NovaRedirectorSeoMiddlewareTest.php
@@ -9,13 +9,7 @@ class NovaRedirectorSeoMiddlewareTest extends TestCase
 {
     public function test_it_redirects_exact_matches(): void
     {
-        NovaRedirectorSeo::query()->create([
-            'from_url' => 'old-page',
-            'to_url' => '/new-page',
-            'status_code' => 301,
-            'enabled' => true,
-            'is_regex' => false,
-        ]);
+        $this->createRule('old-page', '/new-page');
 
         $response = $this->get('/old-page');
 
@@ -23,15 +17,9 @@ class NovaRedirectorSeoMiddlewareTest extends TestCase
         $this->assertSame(301, $response->getStatusCode());
     }
 
-    public function test_it_expands_regex_matches(): void
+    public function test_it_expands_regex_matches_written_with_plain_slashes(): void
     {
-        NovaRedirectorSeo::query()->create([
-            'from_url' => 'posts\/(.*)',
-            'to_url' => '/articles/$1',
-            'status_code' => 302,
-            'enabled' => true,
-            'is_regex' => true,
-        ]);
+        $this->createRule('posts/(.*)', '/articles/$1', statusCode: 302, isRegex: true);
 
         $response = $this->get('/posts/hello-world');
 
@@ -39,23 +27,50 @@ class NovaRedirectorSeoMiddlewareTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    public function test_it_invalidates_the_cached_redirect_when_the_rule_changes(): void
+    public function test_it_still_expands_regex_matches_written_with_escaped_slashes(): void
     {
-        $redirect = NovaRedirectorSeo::query()->create([
-            'from_url' => 'cached-page',
-            'to_url' => '/first-destination',
-            'status_code' => 301,
-            'enabled' => true,
-            'is_regex' => false,
-        ]);
+        $this->createRule('posts\/(.*)', '/articles/$1', isRegex: true);
 
-        $this->get('/cached-page')->assertRedirect('/first-destination');
-        $this->assertNotNull(cache()->get(NovaRedirectorSeo::cacheKey('cached-page')));
+        $this->get('/posts/hello-world')->assertRedirect('/articles/hello-world');
+    }
 
-        $redirect->update([
-            'to_url' => '/second-destination',
-        ]);
+    public function test_it_ignores_a_rule_whose_pattern_does_not_compile(): void
+    {
+        $this->createRule('posts/(unclosed', '/articles', isRegex: true);
+        $this->createRule('posts/(.*)', '/articles/$1', isRegex: true);
 
-        $this->get('/cached-page')->assertRedirect('/second-destination');
+        $this->get('/posts/hello-world')->assertRedirect('/articles/hello-world');
+    }
+
+    public function test_it_ignores_disabled_rules(): void
+    {
+        $this->createRule('old-page', '/new-page', enabled: false);
+
+        $this->get('/old-page')->assertSee('fallback-response');
+    }
+
+    public function test_it_lets_unmatched_paths_through(): void
+    {
+        $this->createRule('old-page', '/new-page');
+
+        $this->get('/some-other-page')->assertSee('fallback-response');
+    }
+
+    private function createRule(
+        string $fromUrl,
+        string $toUrl,
+        int $statusCode = 301,
+        bool $enabled = true,
+        bool $isRegex = false,
+    ): NovaRedirectorSeo {
+        $rule = new NovaRedirectorSeo;
+        $rule->from_url = $fromUrl;
+        $rule->to_url = $toUrl;
+        $rule->status_code = $statusCode;
+        $rule->enabled = $enabled;
+        $rule->is_regex = $isRegex;
+        $rule->save();
+
+        return $rule;
     }
 }

--- a/tests/Feature/RuleCacheTest.php
+++ b/tests/Feature/RuleCacheTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace The3LabsTeam\NovaRedirectorSeo\Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use The3LabsTeam\NovaRedirectorSeo\App\Models\NovaRedirectorSeo;
+use The3LabsTeam\NovaRedirectorSeo\Tests\TestCase;
+
+class RuleCacheTest extends TestCase
+{
+    public function test_it_reads_the_rules_once_for_paths_that_do_not_match(): void
+    {
+        $this->createRule('old-page', '/new-page');
+
+        $this->get('/first-unmatched-path')->assertSee('fallback-response');
+
+        $this->get('/second-unmatched-path')->assertSee('fallback-response');
+        $this->get('/third-unmatched-path')->assertSee('fallback-response');
+
+        $this->assertSame(0, $this->countRuleQueries(fn () => $this->get('/fourth-unmatched-path')));
+    }
+
+    public function test_it_reads_the_rules_once_for_paths_that_match(): void
+    {
+        $this->createRule('old-page', '/new-page');
+
+        $this->get('/old-page')->assertRedirect('/new-page');
+
+        $this->assertSame(0, $this->countRuleQueries(fn () => $this->get('/old-page')));
+    }
+
+    public function test_it_invalidates_the_cache_when_a_rule_changes(): void
+    {
+        $rule = $this->createRule('cached-page', '/first-destination');
+
+        $this->get('/cached-page')->assertRedirect('/first-destination');
+        $this->assertNotNull(cache()->get(NovaRedirectorSeo::cacheKey()));
+
+        $rule->update(['to_url' => '/second-destination']);
+
+        $this->assertNull(cache()->get(NovaRedirectorSeo::cacheKey()));
+        $this->get('/cached-page')->assertRedirect('/second-destination');
+    }
+
+    public function test_it_invalidates_the_cache_when_a_regex_rule_changes(): void
+    {
+        $rule = $this->createRule('posts/(.*)', '/articles/$1', isRegex: true);
+
+        $this->get('/posts/hello-world')->assertRedirect('/articles/hello-world');
+
+        $rule->update(['enabled' => false]);
+
+        $this->get('/posts/hello-world')->assertSee('fallback-response');
+    }
+
+    public function test_it_invalidates_the_cache_when_a_rule_is_deleted(): void
+    {
+        $rule = $this->createRule('old-page', '/new-page');
+
+        $this->get('/old-page')->assertRedirect('/new-page');
+
+        $rule->delete();
+
+        $this->get('/old-page')->assertSee('fallback-response');
+    }
+
+    public function test_it_reads_the_rules_on_every_request_when_the_cache_is_disabled(): void
+    {
+        config()->set('nova-redirector-seo.cache.ttl', 0);
+
+        $rule = $this->createRule('old-page', '/new-page');
+
+        $this->get('/old-page')->assertRedirect('/new-page');
+        $this->assertNull(cache()->get(NovaRedirectorSeo::cacheKey()));
+
+        DB::table('nova_redirector_seo')
+            ->where('id', $rule->id)
+            ->update(['to_url' => '/second-destination']);
+
+        $this->get('/old-page')->assertRedirect('/second-destination');
+    }
+
+    private function countRuleQueries(callable $callback): int
+    {
+        $queries = 0;
+
+        DB::listen(function ($query) use (&$queries) {
+            if (str_contains($query->sql, 'nova_redirector_seo')) {
+                $queries++;
+            }
+        });
+
+        $callback();
+
+        return $queries;
+    }
+
+    private function createRule(
+        string $fromUrl,
+        string $toUrl,
+        int $statusCode = 301,
+        bool $enabled = true,
+        bool $isRegex = false,
+    ): NovaRedirectorSeo {
+        $rule = new NovaRedirectorSeo;
+        $rule->from_url = $fromUrl;
+        $rule->to_url = $toUrl;
+        $rule->status_code = $statusCode;
+        $rule->enabled = $enabled;
+        $rule->is_regex = $isRegex;
+        $rule->save();
+
+        return $rule;
+    }
+}


### PR DESCRIPTION
Two defects found while auditing a production install with ~890 rules.

## Regex rules never matched

Patterns are stored as bare expressions, but they were compiled as `"/$pattern/"`. Any pattern containing a slash — which URL patterns do — closed the delimiter early, so `preg_match()` failed and `testRegex()` reported no match. The rule was skipped **silently**: no exception, no log, nothing in the panel.

The install that surfaced this had the same rule twice: one written naturally (dead), and a second one added later with the slash escaped by hand (working). The existing test also hid the bug, writing `posts\/(.*)` instead of `posts/(.*)`.

Patterns are now wrapped in a delimiter they are allowed to contain, and one that still does not compile is skipped instead of breaking the request. **Patterns already written with escaped slashes keep working**, so no stored rule changes behaviour.

## The rule set was re-read from the database on almost every request

The cache was keyed by request path and stored the resolved redirect — which is `null` whenever no rule matches. `Cache::remember()` treats `null` as a miss, so the two queries ran again, and the `null` was written again, on **every request to every path without a redirect**: almost all of them. The store also grew one entry per URL ever visited, unbounded on a site that gets crawled.

Every enabled rule now lives in a single entry, read once per request and matched in memory. On the audited install this replaces two queries plus a cache write per request with one cache read.

This also fixes invalidation for regex rules, which was impossible before: their entries were keyed by the *matched path*, not by the pattern, so editing one left stale redirects behind until expiry.

## Also

- Tests: 4 → 13, covering both defects, malformed patterns, disabled rules and invalidation.
- README documents how to write rules (anchoring included) and how the cache behaves.
- `config` comments what the TTL actually caps now.

## Upgrade note

`NovaRedirectorSeo::cacheKey()` no longer takes the `from_url` argument — the cache holds one entry for the whole set. Suggest tagging this as **v1.1.0**.

Rules written without escaping start working after this change: on installs where such a rule was duplicated by an escaped copy, check which one wins (lowest id) before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable caching for redirect rules, including automatic refresh after rule changes.
  * Added support for exact and regex-based URL matching, including escaped patterns.
  * Invalid or disabled rules are safely ignored, while unmatched paths continue normally.

* **Documentation**
  * Documented URL matching, regex captures, rule order, cache behavior, and cache configuration.

* **Chores**
  * Updated the roadmap to include support for additional status codes, including 410 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->